### PR TITLE
Allow retrieving associated values from DragState

### DIFF
--- a/DIOCollectionViewExample/DIOCollectionView.swift
+++ b/DIOCollectionViewExample/DIOCollectionView.swift
@@ -24,72 +24,57 @@ class DIODragInfo {
 
 enum DIODragState {
     
-    // user long pressed inside cell 
+    // user long pressed inside cell
     
     case began(location: CGPoint)
     
-    var began: (CGPoint)? {
-        if case let .began(location) = self {
-            return location
-        }
-        return nil
-    }
-    
-    // user entered a view 
+    // user entered a view
     
     case entered(location: CGPoint)
     
-    var entered: (CGPoint)? {
-        if case let .entered(location) = self {
-            return location
-        }
-        return nil
-    }
-    
-    // user moved 
+    // user moved
     
     case moved(location: CGPoint)
     
-    var moved: (CGPoint)? {
-        if case let .moved(location) = self {
-            return location
-        }
-        return nil
-    }
-    
-    // user lifted finger 
+    // user lifted finger
     
     case ended(location: CGPoint)
     
-    var ended: (CGPoint)? {
-        if case let .ended(location) = self {
-            return location
-        }
-        return nil
-    }
-    
-    // user left a view 
+    // user left a view
     
     case left(location: CGPoint)
     
-    var left: (CGPoint)? {
-        if case let .left(location) = self {
-            return location
-        }
-        return nil
-    }
-    
-    // system cancelled 
+    // system cancelled
     
     case cancelled(location: CGPoint)
     
-    var cancelled: (CGPoint)? {
-        if case let .cancelled(location) = self {
+    // location unwrapping
+    
+    var location: CGPoint? {
+        
+        switch (self) {
+            
+        case let .began(location):
             return location
+            
+        case let .entered(location):
+            return location
+            
+        case let .moved(location):
+            return location
+            
+        case let .ended(location):
+            return location
+            
+        case let .left(location):
+            return location
+            
+        case let .cancelled(location):
+            return location
+            
         }
-        return nil
+        
     }
-
 }
 
 protocol DIOCollectionViewDelegate: class {

--- a/DIOCollectionViewExample/DIOCollectionView.swift
+++ b/DIOCollectionViewExample/DIOCollectionView.swift
@@ -23,26 +23,74 @@ class DIODragInfo {
 }
 
 enum DIODragState {
-    // user long pressed inside cell
+    
+    // user long pressed inside cell 
+    
     case began(location: CGPoint)
     
-    // user entered a view
+    var began: (CGPoint)? {
+        if case let .began(location) = self {
+            return location
+        }
+        return nil
+    }
+    
+    // user entered a view 
+    
     case entered(location: CGPoint)
     
-    // user moved
+    var entered: (CGPoint)? {
+        if case let .entered(location) = self {
+            return location
+        }
+        return nil
+    }
+    
+    // user moved 
+    
     case moved(location: CGPoint)
     
-    // user lifted finger
+    var moved: (CGPoint)? {
+        if case let .moved(location) = self {
+            return location
+        }
+        return nil
+    }
+    
+    // user lifted finger 
+    
     case ended(location: CGPoint)
     
-    // user left a view
+    var ended: (CGPoint)? {
+        if case let .ended(location) = self {
+            return location
+        }
+        return nil
+    }
+    
+    // user left a view 
+    
     case left(location: CGPoint)
     
-    // system cancelled
+    var left: (CGPoint)? {
+        if case let .left(location) = self {
+            return location
+        }
+        return nil
+    }
+    
+    // system cancelled 
+    
     case cancelled(location: CGPoint)
+    
+    var cancelled: (CGPoint)? {
+        if case let .cancelled(location) = self {
+            return location
+        }
+        return nil
+    }
+
 }
-
-
 
 protocol DIOCollectionViewDelegate: class {
     


### PR DESCRIPTION
Depending on the use case, it is very important to know the current `DIODragState`–specifically the location (`CGPoint`)– and getting the data out of enums with associated values is actually an issue I ended up running into.

This *PR* basically makes use of other language constructs to allow us to access the inner details of the enum–yeah, I just couldn’t find any other way to have access than the *enum-case-pattern-matching-alike* stuff.

Now, in my `receivedDragWithDragInfo` method from `DIODestinationView` I can, for instance:

```swift
switch(dragState) {
...
case .ended:
    let position = dragState.ended
    let exampleView: UIImageView = UIImageView(image: UIImage(named: example))
    sticker.frame = CGRect(x: (position?.x)!, y: (position?.y)!, width: 100, height: 100)
    self.addSubview(sticker)
...
default:
    break
```

And my `exampleView` will be plotted based on dragging location state.